### PR TITLE
Change sort buffer size limit to be dynamic

### DIFF
--- a/resources/big_accelerator_set.json
+++ b/resources/big_accelerator_set.json
@@ -56,7 +56,7 @@
 	"accelerators": {
 		"filter": "DSPI_filtering",
 		"join": "DSPI_joining",
-        "big_merge": "DSPI_big_merge_sorting",
+        "big_merge": "DSPI_double_merge_sorting",
 		"linear_sort": "DSPI_linear_sorting",
 		"add": "DSPI_addition",
 		"mul": "DSPI_multiplication",

--- a/resources/required_memory_space.json
+++ b/resources/required_memory_space.json
@@ -1,7 +1,7 @@
 {
 	"DSPI_filtering": 2097152,
 	"DSPI_joining": 2097152,
-	"DSPI_double_merge_sorting": 3145728,
+	"DSPI_double_merge_sorting": 369098752,
 	"DSPI_merge_sorting": 2097152,
     "DSPI_big_merge_sorting": 2097152,
 	"DSPI_linear_sorting": 2097152,
@@ -12,6 +12,6 @@
     "DSPI_sort_join_filter": 4194304,
     "DSPI_filter_join": 3145728,
     "DSPI_filtering_linear_sort": 3145728,
-    "ILA_thing": 153092096,
+    "ILA_thing": 369098752,
     "DSPI_add_mul_sum": 4194304
 }

--- a/src/fpga_managing/merge_sort_setup.cpp
+++ b/src/fpga_managing/merge_sort_setup.cpp
@@ -62,7 +62,7 @@ auto MergeSortSetup::CalculateSortBufferSize(int buffer_space,
   int max_buffered_record_count = buffer_space / chunks_per_record -
                                   16;  // -16 for records in the pipelines.
 
-  return std::min(16,
+  return std::min(2 * buffer_space / channel_count,
                   (max_buffered_record_count - internal_logic_buffer_reserve) /
                       channel_count);
 }


### PR DESCRIPTION
Removed hardcoded limit from merge sort module buffer size to be module parameter dependent. In addition, checked in a double merge sort module which doesn't stall on empty streams.

Closes #96